### PR TITLE
Replace non OSS Elasticsearch binary with Apache2 Licensed binary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update &&  apk add ca-certificates wget && apk add ca-certificates curl 
 RUN \
  mkdir /tmp/es && \
  cd /tmp/es && \
- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.6.tar.gz && \
+ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.8.6.tar.gz && \
  tar xvzf elasticsearch-*.tar.gz && \
  rm -f elasticsearch-*.tar.gz && \
  mv /tmp/es/elasticsearch-* /elasticsearch && \


### PR DESCRIPTION
The binary file being built as part of the Docker image was distributed under the Elastic license. This change replaces this binary file with the one distributed by Elastic under the Apache 2 License.

Signed-off-by: Luis Cañas-Díaz <lcanas@bitergia.com>

---

In order to review this code, get the binary file downloaded and have a look at the LICENSE.txt file.

The old one was something like this:
```
$ head elasticsearch-6.8.6/LICENSE.txt 
ELASTIC LICENSE AGREEMENT

PLEASE READ CAREFULLY THIS ELASTIC LICENSE AGREEMENT (THIS "AGREEMENT"), WHICH
CONSTITUTES A LEGALLY BINDING AGREEMENT AND GOVERNS ALL OF YOUR USE OF ALL OF
THE ELASTIC SOFTWARE WITH WHICH THIS AGREEMENT IS INCLUDED ("ELASTIC SOFTWARE")
THAT IS PROVIDED IN OBJECT CODE FORMAT, AND, IN ACCORDANCE WITH SECTION 2 BELOW,
CERTAIN OF THE ELASTIC SOFTWARE THAT IS PROVIDED IN SOURCE CODE FORMAT. BY
INSTALLING OR USING ANY OF THE ELASTIC SOFTWARE GOVERNED BY THIS AGREEMENT, YOU
ARE ASSENTING TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE
WITH SUCH TERMS AND CONDITIONS, YOU MAY NOT INSTALL OR USE THE ELASTIC SOFTWARE
```

The new one is like this:
```
$ head elasticsearch-6.8.6/LICENSE.txt

                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,

```