### PR TITLE
Add ANONYMOUS_USER docker env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# elasticsearch
-Docker build files and other stuff for bitergia_elasticsearch
+# ElasticSearch 6.8.6 secured
+
+Docker build files and other stuff for bitergia_elasticsearch.
+
+The image that the files create contains an ElasticSearch OSS + SearchGuard plugin (Community edition) installed. Moreover there is a docker env variable that can be defined:
+
+- `ANONYMOUS_USER`: If true, the anonymous user will be activated. If not defined or false, the anonymous user will be deactivated. Kibana/Kibiter with SearchGuard kibana-plugin must have activated the anonymous authentication (`ANONYMOUS_USER` if using [Kibiter](https://github.com/chaoss/grimoirelab-kibiter/tree/integration-6.8.6)).

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,6 +20,11 @@ while [[ RET -ne 0 ]]; do
     sleep 5
 done
 
+# Enable Anonymous user
+if [ "$ANONYMOUS_USER" != "" ]; then
+    sed -i "s/anonymous_auth_enabled: false/anonymous_auth_enabled: true/g" $ES_PATH/plugins/search-guard-6/sgconfig/sg_config.yml
+fi
+
 $ES_PATH/plugins/search-guard-6/tools/sgadmin.sh -cd $ES_PATH/plugins/search-guard-6/sgconfig -h 0.0.0.0 -icl -nhnv -cacert $ES_PATH/config/root-ca.pem -cert $ES_PATH/config/kirk.pem -key $ES_PATH/config/kirk-key.pem
 
 fg


### PR DESCRIPTION
This PR adds the functionality of activating/deactivating the anonymous user in the bitergia/elasticsearch docker image.