### PR TITLE
Fix #10 with wrong usage of VOLUME instruction

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,11 +47,11 @@ ADD sg_roles_mapping.yml /usr/share/elasticsearch/plugins/search-guard-6/sgconfi
 # Define working directory.
 WORKDIR /elasticsearch/data
 
-# Define mountable directories.
-VOLUME ["/elasticsearch/data"]
-
 RUN adduser -D -u 1000 esuser && \
     chown -R esuser /elasticsearch
+
+# Define mountable directories.
+VOLUME ["/elasticsearch/data"]
 
 USER esuser
 


### PR DESCRIPTION
The VOLUME instruction was used to set the directory /elasticsearch/data
right before the permission is changed to all the subdirectories of
/elasticsearch. That means those changes were discarded. This patch
fixes this by using the VOLUME instruction to set that directory after
the permissions have been modified.

Signed-off-by: Luis Cañas-Díaz <lcanas@bitergia.com>